### PR TITLE
fix : Update dangerfile.js to have chore(deps) as valid prefix

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -57,6 +57,7 @@ const allowedPrefixes = [
   'feat',
   'fix',
   'chore',
+  'chore(deps)',
   'refactor',
   'style',
   'test',


### PR DESCRIPTION
Add chore(deps) as a valid prefix in dangerfile

> Retried the changes on a fresh PR. and the checks went fine.. merged these changes through the fresh PR (https://github.com/intuit/apollo-mock-http/pull/49). Thanks @atyachari